### PR TITLE
Use a jdk, use container support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY src /tmp/src/
 WORKDIR /tmp/
 RUN mvn package
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM adoptopenjdk:11-jdk-hotspot
 COPY --from=MAVEN_TOOL_CHAIN /tmp/target/is-it-their-birthday-0.0.1-SNAPSHOT.jar /opt/is-it-their-birthday-0.0.1-SNAPSHOT.jar
-ENTRYPOINT ["java", "-jar", "/opt/is-it-their-birthday-0.0.1-SNAPSHOT.jar"]
+ENTRYPOINT ["java", "-XX:+PrintFlagsFinal", "-XX:+UseContainerSupport", "-jar", "/opt/is-it-their-birthday-0.0.1-SNAPSHOT.jar"]
 EXPOSE 8080


### PR DESCRIPTION
This shouldn't take 100s of mb of memory, so add the container support
to limit the heap based on the amount of memory allocated to the
container. Tested with 48m heap.
Use a jdk instead of just a jre in case we need to do additional
troubleshooting in a container